### PR TITLE
adblock-fast: combine filters for domains list type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.1.3
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=AGPL-3.0-or-later
 

--- a/files/etc/init.d/adblock-fast
+++ b/files/etc/init.d/adblock-fast
@@ -88,7 +88,7 @@ readonly runningConfigFile="/dev/shm/${packageName}.config"
 readonly runningErrorFile="/dev/shm/${packageName}.error"
 readonly runningStatusFile="/dev/shm/${packageName}.status"
 readonly hostsFilter='/localhost/d;/^#/d;/^[^0-9]/d;s/^0\.0\.0\.0.//;s/^127\.0\.0\.1.//;s/[[:space:]]*#.*$//;s/[[:cntrl:]]$//;s/[[:space:]]//g;/[`~!@#\$%\^&\*()=+;:"'\'',<>?/\|[{}]/d;/]/d;/\./!d;/^$/d;/[^[:alnum:]_.-]/d;'
-readonly domainsFilter='/^#/d;s/[[:space:]]*#.*$//;s/[[:space:]]*$//;s/[[:cntrl:]]$//;/[[:space:]]/d;/[`~!@#\$%\^&\*()=+;:"'\'',<>?/\|[{}]/d;/]/d;/^$/d;/[^[:alnum:]_.-]/d;'
+readonly domainsFilter='/^#/d;s/[[:space:]]*#.*|[[:space:]]*$|[[:cntrl:]]$//g;/^[[:space:]]*$/d;/^[^[:alnum:]._-]|[`~!@#\$%\^&\*()=+;:"'"'"',<>?/\|{}]/d'
 readonly adBlockPlusFilter='/^#/d;/^!/d;s/[[:space:]]*#.*$//;s/^||//;s/\^$//;s/[[:space:]]*$//;s/[[:cntrl:]]$//;/[[:space:]]/d;/[`~!@#\$%\^&\*()=+;:"'\'',<>?/\|[{}]/d;/]/d;/\./!d;/^$/d;/[^[:alnum:]_.-]/d;'
 readonly dnsmasqFileFilter='\|^server=/[[:alnum:]_.-].*/|!d;s|server=/||;s|/.*$||'
 readonly dnsmasq2FileFilter='\|^local=/[[:alnum:]_.-].*/|!d;s|local=/||;s|/.*$||'


### PR DESCRIPTION
Maintainer: @stangri 
Compile tested: OpenWrt 24.10.1, ramips/mt7621, x86_64
Run tested: OpenWrt 24.10.1, ramips/mt7621, x86_64

Description:
- combine filters for "domains" lists during download step

Test results:

Original (ramips/mt7621):

![image](https://github.com/user-attachments/assets/2a77b873-e683-44c1-aff4-a020ea0dd59f)

Modified (ramips/mt7621):

![image](https://github.com/user-attachments/assets/503356ab-75dd-44ed-b878-a890874b2cc6)

On x86_64 the difference is not so impressive, but also there is no degradation.

Original (x86_64):

![image](https://github.com/user-attachments/assets/5d2e7de0-04f4-4767-ae5f-e858314b80d1)

Modified (x86_64):

![image](https://github.com/user-attachments/assets/3dc41612-1d9d-4fd3-8914-12aa871ce9a7)

