### PR TITLE
adblock-fast:  add uclient-fetch as a fallback client for checking blocklist sizes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.1.3
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=AGPL-3.0-or-later
 

--- a/files/etc/init.d/adblock-fast
+++ b/files/etc/init.d/adblock-fast
@@ -18,7 +18,7 @@ if type extra_command 1>/dev/null 2>&1; then
 	extra_command 'killcache' 'Delete all cached files'
 	extra_command 'pause' 'Pauses AdBlocking for specified number of seconds (default: 60)'
 	extra_command 'show_blocklist' 'List currently blocked domains'
-	extra_command 'sizes' 'Displays the file-sizes of enabled block-lists'
+	extra_command 'sizes' 'Displays the file-sizes of configured block-lists'
 	extra_command 'version' 'Show version information'
 fi
 
@@ -464,12 +464,21 @@ get_local_filesize() {
 }
 
 get_url_filesize() {
-	local url="$1" size size_command
+	local url="$1" size size_command timeout_sec=2
 	[ -n "$url" ] || return 0
-	is_present 'curl' || return 0
-	size_command='curl --silent --insecure --fail --head --request GET'
-	size="$($size_command "$url" | awk -F": " '{IGNORECASE=1}/content-length/ {gsub(/\r/, ""); print $2}' )"
-# shellcheck disable=SC3037
+        if is_present 'curl'; then
+                # shellcheck disable=SC1017
+                size_command='curl --silent --insecure --fail --head --request GET'
+                size="$($size_command --connect-timeout $timeout_sec "$url" | awk -F": " '{IGNORECASE=1}/content-length/ {gsub(/\r/, ""); print $2}' )"
+        fi
+
+        # Check if size is empty and fallback to uclient-fetch if necessary
+        if [ -z "$size" ] && is_present 'uclient-fetch' ; then
+                # shellcheck disable=SC1017
+                size_command='uclient-fetch --spider'
+                size="$($size_command --timeout $timeout_sec "$url" -O /dev/null 2>&1 | sed -n '/^Download/ s/.*(\([0-9]*\) bytes).*/\1/p')"
+        fi
+	# shellcheck disable=SC3037
 	echo -en "$size"
 }
 


### PR DESCRIPTION
Maintainer: @stangri
Compile tested: OpenWrt 24.10.1, ramips/mt7621, x86_64
Run tested: OpenWrt 24.10.1, ramips/mt7621, x86_64

Description:

- Implemented uclient-fetch as a fallback client for checking blocklist sizes
- Established a connection timeout of 2 seconds
- Updated the help message to replace the term "enabled" with "configured"

Fixes: #2 

Result:

![image](https://github.com/user-attachments/assets/4e7aa3d4-3c27-4004-8529-46506eca783c)
