### PR TITLE
adblock-fast: fix jsonfilter parsing dnsmasq instance name

### DIFF
--- a/files/etc/init.d/adblock-fast
+++ b/files/etc/init.d/adblock-fast
@@ -1068,8 +1068,11 @@ load_environment() {
 resolver() {
 	_dnsmasq_instance_get_confdir() {
 		local cfg_file
+		local instance_name
+
+		instance_name=$(uci -q show "dhcp.${1}" | awk -F'[.=]' 'NR==1{print $2}')
 		[ -z "$dnsmasq_ubus" ] && dnsmasq_ubus="$(ubus call service list '{"name":"dnsmasq"}')"
-		cfg_file="$(echo "$dnsmasq_ubus" | jsonfilter -e "@.dnsmasq.instances.${1}.command" \
+		cfg_file="$(echo "$dnsmasq_ubus" | jsonfilter -e "@.dnsmasq.instances.${instance_name}.command" \
 			| awk '{gsub(/\\\//,"/");gsub(/[][",]/,"");for(i=1;i<=NF;i++)if($i=="-C"){print $(i+1);exit}}')"
 		awk -F= '/^conf-dir=/{print $2; exit}' "$cfg_file"
 	}


### PR DESCRIPTION
In https://github.com/mossdef-org/adblock-fast/blob/23a2764d443d8c010ef2e4b7aca907f16d7883d4/files/etc/init.d/adblock-fast#L1346 this is fixed to use input `@dnsmasq[$i]` to indicate dnsmasq instance, but this breaks jsonfilter parsing, resulting in error like
```
[DNSM] Updating dnsmasq configuration Syntax error: Expecting Label or '*'
In expression @.dnsmasq.instances.@dnsmasq[1].command
Near here ------------------------^
```
this PR will resolve the instance index to its name, thus allowing jsonfilter to locate the conf in the ubus output.