### PR TITLE
fix: suggest apk command instead of opkg on apk systems

### DIFF
--- a/files/lib/adblock-fast/adblock-fast.uc
+++ b/files/lib/adblock-fast/adblock-fast.uc
@@ -1215,7 +1215,10 @@ env.load = function(param, validation_result) {
 		}
 		if (length(missing) && param != 'quiet') {
 			output.warning(get_text('warningMissingRecommendedPackages') + ', install them by running:');
-			output.print('opkg update; opkg --force-overwrite install ' + join(' ', missing) + ';');
+			if (is_present('apk'))
+				output.print('apk update; apk add ' + join(' ', missing) + ';');
+			else
+				output.print('opkg update; opkg --force-overwrite install ' + join(' ', missing) + ';');
 		}
 	};
 


### PR DESCRIPTION
If on a new apk supported version, the missing packages warning will now print the correct 'apk add' command instead of assuming 'opkg'.