### PR TITLE
fix: show missing recommended package names

### DIFF
--- a/files/lib/adblock-fast/adblock-fast.uc
+++ b/files/lib/adblock-fast/adblock-fast.uc
@@ -712,7 +712,7 @@ function get_text(r, ...args) {
 	case 'statusTriggerBootWait': return "waiting for trigger (on_boot)";
 	case 'statusTriggerStartWait': return "waiting for trigger (on_start)";
 	case 'warningExternalDnsmasqConfig': return "Use of external dnsmasq config file detected, please set 'dns' option to 'dnsmasq.conf'";
-	case 'warningMissingRecommendedPackages': return "Some recommended packages are missing";
+	case 'warningMissingRecommendedPackages': return sprintf("Recommended packages are missing: %s", a);
 	case 'warningInvalidCompressedCacheDir': return sprintf("Invalid compressed cache directory '%s'", a);
 	case 'warningFreeRamCheckFail': return "Can't detect free RAM";
 	case 'warningParallelDownloadsThrottled': return sprintf("Parallel downloads reduced to %s due to low free memory", a);
@@ -1209,12 +1209,14 @@ env.load = function(param, validation_result) {
 		let missing = [];
 		for (let key in bins) {
 			if (!is_present(bins[key][0])) {
-				push(status_data.warnings, { code: 'warningMissingRecommendedPackages', info: bins[key][1] });
 				push(missing, bins[key][1]);
 			}
 		}
+		if (length(missing))
+			push(status_data.warnings, { code: 'warningMissingRecommendedPackages', info: join(', ', missing) });
+
 		if (length(missing) && param != 'quiet') {
-			output.warning(get_text('warningMissingRecommendedPackages') + ', install them by running:');
+			output.warning(get_text('warningMissingRecommendedPackages', join(', ', missing)) + '; install them by running:');
 			if (is_present('apk'))
 				output.print('apk update; apk add ' + join(' ', missing) + ';');
 			else


### PR DESCRIPTION
I did 

```
root@OpenWrt:~# /etc/init.d/adblock-fast status
adblock-fast 1.2.2-r18 failed to start: processing: Sorting combined block-list.
[ERROR] Failed to download Config Update file!
[ERROR] Failed to download HaGeZi Apple Native Trackers!
[ERROR] Failed to download 1Hosts - Lite!
[ERROR] Failed to download CERT Polska - Dangerous Websites!
[ERROR] Failed to download HaGeZi Windows Office Telemetry!
[ERROR] Failed to download HaGeZi Android Amazon Samsung Xiaomi Trackers!
[ERROR] Failed to create /var/run/adblock-fast/dnsmasq.servers file!
[ERROR] Failed to create block-list or restart DNS resolver!
[WARN] Some recommended packages are missing!
[WARN] Some recommended packages are missing!
[WARN] Some recommended packages are missing!
[WARN] Some recommended packages are missing!
root@OpenWrt:~#
```

and this doesn't look right. Right now it doesn't show clearly which packages are missing. This PR fixes that.