### PR TITLE
adblock-fast: make gateway check configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ define Package/adblock-fast
   PKGARCH:=all
   DEPENDS:= \
 	+curl \
+	+ip \
 	+resolveip \
 	+ucode \
 	+ucode-mod-fs \

--- a/files/etc/config/adblock-fast
+++ b/files/etc/config/adblock-fast
@@ -21,6 +21,7 @@ config adblock-fast 'config'
 #	option download_max_time ''
 	option download_allow_insecure '1'
 	option force_dns '1'
+	option gateway_check 'netifd'
 	list force_dns_port '53'
 	list force_dns_port '853'
 # ports listed below are used by some

--- a/files/etc/config/adblock-fast
+++ b/files/etc/config/adblock-fast
@@ -21,6 +21,10 @@ config adblock-fast 'config'
 #	option download_max_time ''
 	option download_allow_insecure '1'
 	option force_dns '1'
+# gateway_check: how to wait for a default route at startup
+#	netifd (default) wait for a netifd WAN-style default route
+#	kernel           wait for any kernel IPv4/IPv6 default route
+#	none             do not wait for a default route
 	option gateway_check 'netifd'
 	list force_dns_port '53'
 	list force_dns_port '853'

--- a/files/etc/init.d/adblock-fast
+++ b/files/etc/init.d/adblock-fast
@@ -95,6 +95,7 @@ load_validate_config() {
 	uci_load_validate "$packageName" "$packageName" "$1" "${2}${3:+ ${3}}" \
 		'enabled:bool:0' \
 		'force_dns:bool:1' \
+		'gateway_check:or("netifd", "kernel", "none"):netifd' \
 		'force_dns_interface:list(network):lan' \
 		'force_dns_port:list(integer):53,853' \
 		'parallel_downloads:bool:1' \

--- a/files/lib/adblock-fast/adblock-fast.uc
+++ b/files/lib/adblock-fast/adblock-fast.uc
@@ -1239,8 +1239,8 @@ env.load = function(param, validation_result) {
 	};
 
 	let _check_kernel_gateway = function() {
-		return system("ip -4 route show default 2>/dev/null | grep -q '^default'") == 0 ||
-			system("ip -6 route show default 2>/dev/null | grep -q '^default'") == 0;
+		return system("ip -4 route show default 2>/dev/null | grep -q .") == 0 ||
+			system("ip -6 route show default 2>/dev/null | grep -q .") == 0;
 	};
 
 	let _check_wan_gateway = function() {

--- a/files/lib/adblock-fast/adblock-fast.uc
+++ b/files/lib/adblock-fast/adblock-fast.uc
@@ -912,6 +912,7 @@ const config_schema = { // ucode-lsp disable
 	download_connect_timeout: ['string', '10'],
 	download_max_time:       ['string'],
 	download_timeout:        ['string', '20'],
+	gateway_check:           ['string', 'netifd'],
 	heartbeat_sleep_timeout: ['string', '10'],
 	led:                     ['string'],
 	pause_timeout:           ['string', '20'],
@@ -1224,7 +1225,7 @@ env.load = function(param, validation_result) {
 		}
 	};
 
-	let _check_wan_gateway = function() {
+	let _check_netifd_gateway = function() {
 		let ub = connect();
 		if (!ub) return false;
 		let dump = ub.call('network.interface', 'dump');
@@ -1232,9 +1233,26 @@ env.load = function(param, validation_result) {
 		if (!dump?.interface) return false;
 		for (let iface in dump.interface) {
 			for (let r in (iface.route || []))
-				if (r.target == '0.0.0.0') return true;
+				if (r.target == '0.0.0.0' || r.target == '::') return true;
 		}
 		return false;
+	};
+
+	let _check_kernel_gateway = function() {
+		return system("ip -4 route show default 2>/dev/null | grep -q '^default'") == 0 ||
+			system("ip -6 route show default 2>/dev/null | grep -q '^default'") == 0;
+	};
+
+	let _check_wan_gateway = function() {
+		switch (cfg.gateway_check) {
+		case 'none':
+			return true;
+		case 'kernel':
+			return _check_kernel_gateway();
+		case 'netifd':
+		default:
+			return _check_netifd_gateway();
+		}
 	};
 
 	// ── param-driven branches ───────────────────────────────────────

--- a/tests/mocks/uci/adblock-fast.json
+++ b/tests/mocks/uci/adblock-fast.json
@@ -7,6 +7,7 @@
 			"dns": "dnsmasq.servers",
 			"verbosity": "0",
 			"force_dns": "0",
+			"gateway_check": "none",
 			"compressed_cache": "0",
 			"config_update_enabled": "0",
 			"ipv6_enabled": "0",


### PR DESCRIPTION
The current netifd check works for regular OpenWrt WAN interfaces, but it can fail on routers where default routing is installed by routing daemons rather than exposed as an interface route in `ubus call network.interface dump`.

One example is Freifunk mesh core routers using Babel or OLSR. These nodes may have usable IPv4 or IPv6 default routing in the kernel, while netifd does not report a WAN-style default route. `gateway_check=kernel` allows adblock-fast to wait for kernel default route availability in those setups, while `gateway_check=none` supports environments where startup should not be gated on default-route discovery at all.

The default remains `netifd`, so existing behavior is unchanged for normal OpenWrt routers.